### PR TITLE
Fix RustChain branding in README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ ROCm components retain AMD's original licenses.
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 raised
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Fix the README footer link text from `Star Rustchain` to `Star RustChain`.
- Preserve the existing RustChain repository URL and surrounding footer links.

## Validation
- git diff --check
- duplicate check: no open amd-rocm-power8-patches PRs and no matching branding/capitalization PR search results before publishing
- duplicate check: no rustchain-bounties#2178 amd-rocm-power8-patches comment found before claim/publication

## Bounty
- rustchain-bounties#2178 docs/typo fix bounty.
